### PR TITLE
Feature/state has changed

### DIFF
--- a/src/Memento.Core/AbstractStore.cs
+++ b/src/Memento.Core/AbstractStore.cs
@@ -1,5 +1,7 @@
 ﻿using Memento.Core.Internals;
 using Memento.Core.Store.Internals;
+using System.Dynamic;
+using System.Threading.Channels;
 
 namespace Memento.Core;
 
@@ -79,6 +81,11 @@ public abstract class AbstractStore<TState, TCommand>
         });
     }
 
+    /// <summary>
+    /// Notifies that the state of the Store has changed.
+    /// Usually, you don't need to call when you change the state
+    /// via <see cref="FluxStore{TState, TCommand}.Dispatch"/> or <see cref="Store{TState}.Mutate"/>.
+    /// </summary>
     public void StateHasChanged() {
         InvokeObserver(new StateChangedEventArgs<TState>() {
             State = State,

--- a/src/Memento.Core/AbstractStore.cs
+++ b/src/Memento.Core/AbstractStore.cs
@@ -79,6 +79,15 @@ public abstract class AbstractStore<TState, TCommand>
         });
     }
 
+    public void StateHasChanged() {
+        InvokeObserver(new StateChangedEventArgs<TState>() {
+            State = State,
+            LastState = State,
+            Command = new Command.StateHasChanged(State),
+            Sender = this,
+        });
+    }
+
     public Type GetStateType() {
         return typeof(TState);
     }

--- a/test/Memento.Test/Core/FluxStoreTest.cs
+++ b/test/Memento.Test/Core/FluxStoreTest.cs
@@ -141,4 +141,31 @@ public class FluxStoreTest {
         Assert.Equal(10000, commands.Count);
         Assert.True(sw.ElapsedMilliseconds < 200);
     }
+
+    [Fact]
+    public void Ensure_StateHasChangedInvoked() {
+        var store = new FluxAsyncCounterStore();
+        var commands = new List<Command>();
+
+        var lastState = store.State;
+        using var subscription = store.Subscribe(e => {
+            commands.Add(e.Command);
+        });
+
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+
+        Assert.True(commands is [
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+        ]);
+    }
 }

--- a/test/Memento.Test/Core/StoreTest.cs
+++ b/test/Memento.Test/Core/StoreTest.cs
@@ -137,4 +137,32 @@ public class StoreTest {
         Assert.Equal(10000, commands.Count);
         Assert.True(sw.ElapsedMilliseconds < 200);
     }
+
+    [Fact]
+    public void Ensure_StateHasChangedInvoked() {
+        var store = new AsyncCounterStore();
+
+        var commands = new List<Command>();
+
+        var lastState = store.State;
+        using var subscription = store.Subscribe(e => {
+            commands.Add(e.Command);
+        });
+
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+        store.StateHasChanged();
+
+        Assert.True(commands is [
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+            Command.StateHasChanged,
+        ]);
+    }
 }


### PR DESCRIPTION
Implemented StateHasChanged in the AbstractStore, 
which notifies that the state of the Store has changed, 
usually you don't need to call because the state is changed via Dispatch or Mutate.